### PR TITLE
Fix for EOBS-1001.

### DIFF
--- a/nh_eobs/tests/common/nh_clinical_test_utils.py
+++ b/nh_eobs/tests/common/nh_clinical_test_utils.py
@@ -110,13 +110,15 @@ class NhClinicalTestUtils(AbstractModel):
             'hca': other_hca
         }
 
-    def complete_open_activity(self, data_model, user_id=None):
+    def complete_open_activity(self, data_model, user_id=None, vals=None):
         """
         Find and complete open activity in specified model
 
         :param data_model: Model to complete
         :param user_id: user to complete as
         """
+        if not vals:
+            vals = {}
         if not user_id:
             user_id = self.nurse.id
         api_pool = self.pool['nh.eobs.api']
@@ -130,7 +132,7 @@ class NhClinicalTestUtils(AbstractModel):
             self.env.cr,
             user_id,
             task.id,
-            {}
+            vals
         )
 
     def cancel_open_activity(self, data_model, user_id=None):

--- a/nh_eobs_mental_health/models/nh_eobs_mobile_main.py
+++ b/nh_eobs_mental_health/models/nh_eobs_mobile_main.py
@@ -1,7 +1,7 @@
-from openerp.osv import orm
-import openerp.modules as addons
 import openerp.addons.nh_eobs_mobile.controllers.main as mobile_controller
+import openerp.modules as addons
 from openerp.addons.nh_eobs_mobile.controllers.urls import URLS
+from openerp.osv import orm
 
 
 class NHEobsMobileMain(orm.AbstractModel):
@@ -9,6 +9,15 @@ class NHEobsMobileMain(orm.AbstractModel):
     _name = 'nh.eobs.mobile.mental'
 
     def process_patient_list(self, cr, uid, patient_list, context=None):
+        """
+        Process the patient list.
+
+        :param cr:
+        :param uid:
+        :param patient_list:
+        :param context:
+        :return:
+        """
         spell_model = self.pool['nh.clinical.spell']
         patient_ids = [patient.get('id') for patient in patient_list]
         spell_ids = spell_model.search(cr, uid, [

--- a/nh_observations/notifications.py
+++ b/nh_observations/notifications.py
@@ -106,14 +106,14 @@ class nh_clinical_notification_frequency(orm.Model):
 
     def complete(self, cr, uid, activity_id, context=None):
         activity_pool = self.pool['nh.activity']
-        review_frequency = activity_pool.browse(
+        activity_review_frequency = activity_pool.browse(
             cr, uid, activity_id, context=context
         )
-        patient_id = review_frequency.data_ref.patient_id.id
-        observation_type = review_frequency.data_ref.observation
+        spell_activity_id = activity_review_frequency.spell_activity_id.id
+        observation_model_name = activity_review_frequency.data_ref.observation
         domain = [
-            ('patient_id', '=', patient_id),
-            ('data_model', '=', observation_type),
+            ('spell_activity_id', '=', spell_activity_id),
+            ('data_model', '=', observation_model_name),
             ('state', 'not in', ['completed', 'cancelled'])
         ]
         obs_ids = activity_pool.search(
@@ -125,10 +125,10 @@ class nh_clinical_notification_frequency(orm.Model):
                       "of the currently open obs but no open obs were found."
             raise ValueError(message)
         obs = activity_pool.browse(cr, uid, obs_ids[0], context=context)
-        obs_pool = self.pool[review_frequency.data_ref.observation]
+        obs_pool = self.pool[activity_review_frequency.data_ref.observation]
         obs_pool.write(
             cr, uid, obs.data_ref.id,
-            {'frequency': review_frequency.data_ref.frequency},
+            {'frequency': activity_review_frequency.data_ref.frequency},
             context=context)
         return super(nh_clinical_notification_frequency, self).complete(
             cr, uid, activity_id, context=context)

--- a/nh_observations/tests/__init__.py
+++ b/nh_observations/tests/__init__.py
@@ -1,6 +1,5 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
-from . import test_review_frequency_complete
-from . import test_review_frequency_form_description
 from .frequencies import test_frequencies
-from . nh_clinical_patient_observation import *
+from .nh_clinical_notification_frequency import *
+from .nh_clinical_patient_observation import *
 

--- a/nh_observations/tests/nh_clinical_notification_frequency/__init__.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/__init__.py
@@ -1,0 +1,5 @@
+from . import test_field_validation
+from . import test_review_frequency_complete
+from . import test_review_frequency_form_description
+
+

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
@@ -8,10 +8,13 @@ class TestFieldValidation(TransactionCase):
 
     def setUp(self):
         super(TestFieldValidation, self).setUp()
+        self.test_utils = self.env['nh.clinical.test_utils']
+        self.test_utils.create_patient_and_spell()
+        self.test_utils.copy_instance_variables(self)
+
         self.notification_frequency_model = \
             self.env['nh.clinical.notification.frequency']
         self.frequency = frequencies.as_list()[0][0]
-        self.fake_patient_id = 1
 
     def test_not_observation_model_name_fails_validation(self):
         not_an_observation = 'nh.clinical.patient.blooblah'
@@ -19,7 +22,7 @@ class TestFieldValidation(TransactionCase):
             self.notification_frequency_model.create({
                 'frequency': self.frequency,
                 'observation': not_an_observation,
-                'patient_id': self.fake_patient_id
+                'patient_id': self.patient.id
             })
 
     def test_observation_model_name_passes_validation(self):
@@ -27,5 +30,5 @@ class TestFieldValidation(TransactionCase):
         self.notification_frequency_model.create({
             'frequency': self.frequency,
             'observation': an_observation,
-            'patient_id': self.fake_patient_id
+            'patient_id': self.patient.id
         })

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from openerp import exceptions
+from openerp.addons.nh_observations import frequencies
+from openerp.tests.common import TransactionCase
+
+
+class TestFieldValidation(TransactionCase):
+
+    def setUp(self):
+        super(TestFieldValidation, self).setUp()
+        self.notification_frequency_model = \
+            self.env['nh.clinical.notification.frequency']
+        self.frequency = frequencies.as_list()[0][0]
+        self.fake_patient_id = 1
+
+    def test_not_observation_model_name_fails_validation(self):
+        not_an_observation = 'nh.clinical.patient.blooblah'
+        with self.assertRaises(exceptions.ValidationError):
+            self.notification_frequency_model.create({
+                'frequency': self.frequency,
+                'observation': not_an_observation,
+                'patient_id': self.fake_patient_id
+            })
+
+    def test_observation_model_name_passes_validation(self):
+        an_observation = 'nh.clinical.patient.observation.ews'
+        self.notification_frequency_model.create({
+            'frequency': self.frequency,
+            'observation': an_observation,
+            'patient_id': self.fake_patient_id
+        })

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_field_validation.py
@@ -26,7 +26,7 @@ class TestFieldValidation(TransactionCase):
             })
 
     def test_observation_model_name_passes_validation(self):
-        an_observation = 'nh.clinical.patient.observation.ews'
+        an_observation = 'nh.clinical.patient.observation.foo'
         self.notification_frequency_model.create({
             'frequency': self.frequency,
             'observation': an_observation,

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_complete.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_complete.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from openerp.tests.common import SingleTransactionCase
 import __builtin__
+
+from openerp.tests.common import TransactionCase, SingleTransactionCase
 
 
 class MockSuperWithComplete(object):
@@ -100,8 +101,15 @@ class TestReviewFrequencyComplete(SingleTransactionCase):
         Test that the complete method uses the submitted patient_id and
         observation parameters to search for the most recent open observation
         """
-        self.review_freq_pool.complete(self.cr, self.uid, 'rev_freq_browse',
-                                       context='test_rev_freq_search_domain')
+        try:
+            self.review_freq_pool.complete(
+                self.cr, self.uid, 'rev_freq_browse',
+                context='test_rev_freq_search_domain'
+            )
+        except ValueError:
+            # Exception correctly thrown, catch it and do nothing, we just want
+            # to see inspect the search domain that was used.
+            pass
         self.assertEqual(search_domain, [
             ('patient_id', '=', self.patient),
             ('data_model', '=', self.OBSERVATION_TYPE),
@@ -117,12 +125,36 @@ class TestReviewFrequencyComplete(SingleTransactionCase):
                                        context='test_rev_freq_update')
         self.assertEqual(update_dict, {'frequency': self.SUBMITTED_FREQ})
 
-    def test_does_not_update_if_no_obs_found(self):
-        """
-        Test that the complete method does not update the frequency if there
-        are no observations found
-        """
-        self.calls_to_write = 0
-        self.review_freq_pool.complete(self.cr, self.uid, 'rev_freq_browse',
-                                       context='test_rev_freq_no_update')
-        self.assertEqual(self.calls_to_write, 0)
+
+class TestNoOpenObsFound(TransactionCase):
+
+    def setUp(self):
+        super(TestNoOpenObsFound, self).setUp()
+        self.notification_frequency_model = \
+            self.env['nh.clinical.notification.frequency']
+        self.activity_model = self.env['nh.activity']
+        self.observation_model = self.env['nh.clinical.patient.observation']
+
+        notification_frequency = self.notification_frequency_model.new()
+        activity = self.activity_model.new({
+            'patient_id': 1,
+            'observation': 'foo'
+        })
+        activity.data_ref = notification_frequency
+
+        def browse_stub(*args, **kwargs):
+            return activity
+        def search_stub(*args, **kwargs):
+            return []
+        self.activity_model._patch_method('browse', browse_stub)
+        self.activity_model._patch_method('search', search_stub)
+
+    def test_no_obs_found_raises_exception(self):
+        with self.assertRaises(ValueError):
+            fake_activity_id = 1
+            self.notification_frequency_model.complete(fake_activity_id)
+
+    def tearDown(self):
+        self.activity_model._revert_method('browse')
+        self.activity_model._revert_method('search')
+        super(TestNoOpenObsFound, self).tearDown()

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_complete.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_complete.py
@@ -144,8 +144,10 @@ class TestNoOpenObsFound(TransactionCase):
 
         def browse_stub(*args, **kwargs):
             return activity
+
         def search_stub(*args, **kwargs):
             return []
+
         self.activity_model._patch_method('browse', browse_stub)
         self.activity_model._patch_method('search', search_stub)
 

--- a/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_form_description.py
+++ b/nh_observations/tests/nh_clinical_notification_frequency/test_review_frequency_form_description.py
@@ -1,7 +1,6 @@
 # coding: utf-8
-from openerp.tests.common import SingleTransactionCase
-
 from openerp.addons.nh_observations import frequencies
+from openerp.tests.common import SingleTransactionCase
 
 
 class TestReviewFrequencyFormDesc(SingleTransactionCase):


### PR DESCRIPTION
- Added validation to `observation` field on `nh.clinical.notification.frequency` so that it cannot be set to a non-observation model.
- Ensured that an exception is raised in `complete` method of `nh.clinical.notification.frequency` if no observations are found for frequency adjustment.