### PR TITLE
Eobs 1864 floating footer issue

### DIFF
--- a/nh_eobs_mobile/static/dev/less/src/general.less
+++ b/nh_eobs_mobile/static/dev/less/src/general.less
@@ -83,6 +83,7 @@ Styleguide 1.1
 @import "utils.less";
 .content{
   margin-top: 6.5em;
+  margin-bottom: 2em;
   &.no-menu{
     margin-top: 4em;
   }

--- a/nh_eobs_mobile/static/src/css/nhc.css
+++ b/nh_eobs_mobile/static/src/css/nhc.css
@@ -633,6 +633,7 @@ Styleguide 1.1
 */
 .content {
   margin-top: 6.5em;
+  margin-bottom: 2em;
 }
 .content.no-menu {
   margin-top: 4em;


### PR DESCRIPTION
Floating footer was overlapping the submission button which caused the automation tests to fail when the o2 devices menu was open.

Adding 2em margin to main-content container meant that the floating footer had space put aside for it in the page flow and it would no longer overlap anything when scrolling to bottom of page.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.