### PR TITLE
EOBS-1864

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
   - ODOO_REPO="bjss/odoo" TESTS="1"
     EXCLUDE="base,web,nh_odoo_fixes,nh_activity,nh_clinical,xml_test_output"
     INCLUDE="nh_ews,nh_gcs,nh_graphs,nh_neurovascular,nh_observations,nh_pbp,nh_stools,nh_urinary_analysis,nh_vips,nh_eobs,nh_eobs_api,nh_eobs_backup,nh_eobs_default,nh_eobs_kiosk,nh_eobs_theme,nh_eobs_mobile,nh_eobs_mental_health,nh_neurological,nh_food_and_fluid,nh_weight,nh_blood_glucose,nh_bed_management_mental_health"
-    VERSION="liveobs_1.0"
+    VERSION="liveobs_1.11.1"
 
 virtualenv:
   system_site_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
 - cd odoo_xml_test_output
 - pip install -r requirements.txt
 # Install a pinned version of the dependencies so when OCA's requirements.txt is installed the dependency at this particular version is met
-- pip install PyChart==1.39
+- pip install Python-Chart==1.39
 - pip install astroid==1.3.8
 - pip install Pillow==2.5.1
 - pip install lxml==3.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ before_install:
 - cd odoo_xml_test_output
 - pip install -r requirements.txt
 # Install a pinned version of the dependencies so when OCA's requirements.txt is installed the dependency at this particular version is met
+- pip install PyChart==1.39
 - pip install astroid==1.3.8
 - pip install Pillow==2.5.1
 - pip install lxml==3.8.0

--- a/nh_eobs_mobile/static/dev/less/src/general.less
+++ b/nh_eobs_mobile/static/dev/less/src/general.less
@@ -83,6 +83,7 @@ Styleguide 1.1
 @import "utils.less";
 .content{
   margin-top: 6.5em;
+  margin-bottom: 2em;
   &.no-menu{
     margin-top: 4em;
   }

--- a/nh_eobs_mobile/static/src/css/nhc.css
+++ b/nh_eobs_mobile/static/src/css/nhc.css
@@ -633,6 +633,7 @@ Styleguide 1.1
 */
 .content {
   margin-top: 6.5em;
+  margin-bottom: 2em;
 }
 .content.no-menu {
   margin-top: 4em;


### PR DESCRIPTION
Floating footer was overlapping the submission button which caused the automation tests to fail when the o2 devices menu was open.

Adding 2em margin to main-content container meant that the floating footer had space put aside for it in the page flow and it would no longer overlap anything when scrolling to bottom of page.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.