### PR TITLE
[EOBS-1631] Cancel transfer patient remains in patients by ward

### DIFF
--- a/nh_eobs/tests/__init__.py
+++ b/nh_eobs/tests/__init__.py
@@ -1,17 +1,18 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
 
 # Misc Tests
-from . import test_api_get_activities_settings
-from . import test_eobs_settings
-from . import test_helpers
-from . import test_sql_statements
-from . import test_workload
-from .nh_clinical_observation_report_wizard import *
-from .nh_clinical_patient_monitoring_exception import *
-from .nh_clinical_wardboard import *
-from .nh_eobs_api import *
-from .nh_eobs_ward_dashboard import *
-from .report_nh_clinical_observation_report import *
+# from . import test_api_get_activities_settings
+# from . import test_eobs_settings
+# from . import test_helpers
+# from . import test_sql_statements
+# from . import test_workload
+# from .nh_clinical_observation_report_wizard import *
+# from .nh_clinical_patient_monitoring_exception import *
+# from .nh_clinical_wardboard import *
+# from .nh_eobs_api import *
+# from .nh_eobs_ward_dashboard import *
+# from .report_nh_clinical_observation_report import *
+from .nh_clinical_patient_transfer import *
 
 # Disabled tests
 # from . import test_api_demo

--- a/nh_eobs/tests/__init__.py
+++ b/nh_eobs/tests/__init__.py
@@ -1,18 +1,18 @@
 # Part of Open eObs. See LICENSE file for full copyright and licensing details.
 
 # Misc Tests
-# from . import test_api_get_activities_settings
-# from . import test_eobs_settings
-# from . import test_helpers
-# from . import test_sql_statements
-# from . import test_workload
-# from .nh_clinical_observation_report_wizard import *
-# from .nh_clinical_patient_monitoring_exception import *
-# from .nh_clinical_wardboard import *
-# from .nh_eobs_api import *
-# from .nh_eobs_ward_dashboard import *
-# from .report_nh_clinical_observation_report import *
+from . import test_api_get_activities_settings
+from . import test_eobs_settings
+from . import test_helpers
+from . import test_sql_statements
+from . import test_workload
+from .nh_clinical_observation_report_wizard import *
+from .nh_clinical_patient_monitoring_exception import *
 from .nh_clinical_patient_transfer import *
+from .nh_clinical_wardboard import *
+from .nh_eobs_api import *
+from .nh_eobs_ward_dashboard import *
+from .report_nh_clinical_observation_report import *
 
 # Disabled tests
 # from . import test_api_demo

--- a/nh_eobs/tests/nh_clinical_patient_transfer/__init__.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/__init__.py
@@ -1,0 +1,1 @@
+from . import test_patient_transfer_cancel

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -7,7 +7,7 @@ class TestPatientTransferCancel(TransactionCase):
     def setUp(self):
         super(TestPatientTransferCancel, self).setUp()
         self.test_utils = self.env['nh.clinical.test_utils']
-        self.test_utils.admit_and_place_patient()
+        self.test_utils.admit_and_place_patient(create_placement=False)
         self.test_utils.copy_instance_variables(self)
 
         self.placement_model = self.env['nh.clinical.patient.placement']

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -73,8 +73,12 @@ class TestPatientTransferCancel(TransactionCase):
 
         self.call_test()
 
-        placement = self.get_open_placements()
-        placement.ensure_one()
+        placement_view_model = self.env['nh.clinical.placement']
+        placement_view_model.init()
+        placement = placement_view_model.search([
+            ('patient_id', '=', self.patient.id),
+            ('state', 'not in', ['completed', 'cancelled'])
+        ])
 
-        self.assertNotIn(shift_coordinator_ward_b.id, placement.user_ids)
-        self.assertIn(shift_coordinator_ward_a.id, placement.user_ids)
+        self.assertNotIn(shift_coordinator_ward_b, placement.user_ids)
+        self.assertIn(shift_coordinator_ward_a, placement.user_ids)

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from openerp.tests.common import TransactionCase
+
+
+class TestPatientTransferCancel(TransactionCase):
+
+    def setUp(self):
+        super(TestPatientTransferCancel, self).setUp()
+        self.test_utils = self.env['nh.clinical.test_utils']
+        self.test_utils.admit_and_place_patient()
+        self.test_utils.copy_instance_variables(self)
+
+        self.placement_model = self.env['nh.clinical.patient.placement']
+        self.bed_id_before_transfer = self.patient.current_location_id
+
+    def call_test(self):
+        self.placement_ward_a = self.placement_model.search([
+            ('patient_id', '=', self.patient.id),
+        ])
+        self.placement_ward_a.ensure_one()
+
+        ward_b_code = self.test_utils.other_ward.code
+        self.test_utils.transfer_patient(ward_b_code)
+        self.bed_id_after_transfer = self.patient.current_location_id
+
+        self.placement_ward_b = self.get_open_placements()
+        self.placement_ward_b.ensure_one()
+
+        self.transfer_model = self.env['nh.clinical.patient.transfer']
+        transfer = self.transfer_model.search([
+            ('patient_id', '=', self.patient.id)
+        ])
+        transfer.ensure_one()
+        transfer.cancel(transfer.activity_id.id)
+
+    def test_new_placement_scheduled_when_original_bed_is_not_available(self):
+        """
+        If the bed the patient was in before is no longer available then a new
+        placement should be created for their original ward.
+        """
+        self.call_test()
+        placement = self.get_open_placements()
+        self.assertEqual(1, len(placement))
+        self.assertEqual('scheduled', placement.state)
+        self.assertNotEqual(placement.id, self.placement_ward_a.id)
+        self.assertNotEqual(placement.id, self.placement_ward_b.id)
+
+    def test_only_shift_coordinator_from_original_ward_in_user_ids(self):
+        """
+        Regression for EOBS-1631. Patients should not be visible in the
+        'Patients by Ward' view after their transfer to that ward has been
+        cancelled.
+
+        It seems that this view only shows placements when the ID of the
+        viewing user (a shift coordinator) is in the `user_ids` of the
+        placement record. Therefore asserting that the shift coordinator's
+        user ID is not present should assert that it is not visible in the
+        'Patients by Ward' view.
+        """
+        ward_a = self.test_utils.ward
+        shift_coordinator_ward_a = self.test_utils.create_shift_coordinator(
+            ward_a.id)
+        ward_b = self.test_utils.other_ward
+        shift_coordinator_ward_b = self.test_utils.create_shift_coordinator(
+            ward_b.id)
+
+        self.call_test()
+
+        placement = self.get_open_placements()
+        placement.ensure_one()
+
+        self.assertNotIn(shift_coordinator_ward_b.id, placement.user_ids)
+        self.assertIn(shift_coordinator_ward_a.id, placement.user_ids)

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -89,8 +89,9 @@ class TestPatientTransferCancel(TransactionCase):
         to the test cursor so the test data is not returned by those
         queries.
 
-        Instead this is tested less directly by asserting that the location of
-        the latest placement is correct.
+        Instead this is tested less directly by asserting that the parent
+        location of the latest placement is the original ward and not the
+        destination ward of the cancelled transfer.
         """
         # Get latest placement
         placement = self.placement_model.search([

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -3,7 +3,9 @@ from openerp.tests.common import TransactionCase
 
 
 class TestPatientTransferCancel(TransactionCase):
-
+    """
+    Test cancelling of a patient transfer.
+    """
     def setUp(self):
         super(TestPatientTransferCancel, self).setUp()
         self.test_utils = self.env['nh.clinical.test_utils']

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -39,6 +39,16 @@ class TestPatientTransferCancel(TransactionCase):
             ('state', 'not in', ['completed', 'cancelled'])
         ])
 
+    def test_no_open_placements_when_original_bed_is_available(self):
+        """
+        If the bed the patient was in before is still
+        available, then the new, scheduled placement should
+        be cancelled leaving no open placements.
+        """
+        self.call_test()
+        placements = self.get_open_placements()
+        self.assertEqual(0, len(placements))
+
     def test_new_placement_scheduled_when_original_bed_is_not_available(self):
         """
         If the bed the patient was in before is no longer available then a new

--- a/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
+++ b/nh_eobs/tests/nh_clinical_patient_transfer/test_patient_transfer_cancel.py
@@ -33,10 +33,17 @@ class TestPatientTransferCancel(TransactionCase):
         transfer.ensure_one()
         transfer.cancel(transfer.activity_id.id)
 
+    def get_open_placements(self):
+        return self.placement_model.search([
+            ('patient_id', '=', self.patient.id),
+            ('state', 'not in', ['completed', 'cancelled'])
+        ])
+
     def test_new_placement_scheduled_when_original_bed_is_not_available(self):
         """
         If the bed the patient was in before is no longer available then a new
         placement should be created for their original ward.
+        The first 2 placements should be closed.
         """
         self.call_test()
         placement = self.get_open_placements()


### PR DESCRIPTION
Patients now correctly disappear from the **Patient by Ward** page for a ward they have been transferred to when that transfer is cancelled.

When a transfer is cancelled, is the patients original bed is available, then their latest _placement_ record is cancelled. The previous _placement_ for the patient from before their transfer is still in place in a completed state and this is considered an acceptable state for the data at this point.

If the patient's original bed is no longer available, then their latest placement is still cancelled, and the policy is triggered as if they had just come into the ward as normal, which creates and schedules a brand new placement. They will once again be visible on the **Patients by Ward** page for their original ward.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.