### PR TITLE
Removing deprecated Safari from Graph JS tests

### DIFF
--- a/nh_graphs/dev/coffee/travis-karma.conf.js
+++ b/nh_graphs/dev/coffee/travis-karma.conf.js
@@ -22,13 +22,6 @@ module.exports = function (config) {
             version: '50.0',
             platform: 'Windows 10',
             timeZone: 'Universal'
-        },
-        'SL_WebKit': {
-            base: 'SauceLabs',
-            browserName: 'safari',
-            version: '5.1',
-            platform: 'Windows 7',
-            timeZone: 'Universal'
         }
     };
 


### PR DESCRIPTION
Saucelabs have deprecated Safari 5.1 which was used to ensure compatibility with WKHTMLtoPDF which uses a version of webkit found in this version of Safari.

As we can no longer use SauceLabs to test against this browser we should look to run tests with WKHTMLtoPDF if possible to ensure compatibility.

---

Before this pull request can be merged the following must be true.
- [x] Unit tests pass (Travis integration).
- [x] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.