### PR TITLE
[EOBS-2359] Shift Coordinator has ability to edit locations

### DIFF
--- a/nh_eobs/views/wardboard_view.xml
+++ b/nh_eobs/views/wardboard_view.xml
@@ -102,15 +102,15 @@
             <field name="arch" type="xml">
                 <form string="Wardboard Patient Placement">
                     <group string="From" colspan="4" col="2">
-                        <field name="ward_location_id" readonly="1"/>
-                        <field name="bed_src_location_id" readonly="1" />
+                        <field name="ward_location_id" readonly="1" options="{'no_open': True}"/>
+                        <field name="bed_src_location_id" readonly="1" options="{'no_open': True}"/>
                     </group>
                     <group string="To" colspan="4" col="2">
                         <field name="bed_dst_location_id" width="100" domain="[('id','child_of',ward_location_id),
                                                                              ('usage','=','bed'),
                                                                              ('is_available','=',True),
                                                                              ('id','!=',bed_src_location_id)]"
-                               widget="many2one" required="1" options="{'no_open': True}"/>
+                               widget="many2one" required="1" options="{'no_open': True, 'no_create_edit': True}"/>
                     </group>
                     <button name="do_move" type="object" string="Move"/>
                 </form>

--- a/nh_eobs/views/wardboard_view.xml
+++ b/nh_eobs/views/wardboard_view.xml
@@ -110,8 +110,7 @@
                                                                              ('usage','=','bed'),
                                                                              ('is_available','=',True),
                                                                              ('id','!=',bed_src_location_id)]"
-                               no_open="1" no_create_edit="1" widget="many2one"
-                               required="1" options="{'no_create': True}"/>
+                               widget="many2one" required="1" options="{'no_open': True}"/>
                     </group>
                     <button name="do_move" type="object" string="Move"/>
                 </form>

--- a/nh_eobs/views/wardboard_view.xml
+++ b/nh_eobs/views/wardboard_view.xml
@@ -102,8 +102,8 @@
             <field name="arch" type="xml">
                 <form string="Wardboard Patient Placement">
                     <group string="From" colspan="4" col="2">
-                        <field name="ward_location_id" readonly="1" options="{'no_open': True}"/>
-                        <field name="bed_src_location_id" readonly="1" options="{'no_open': True}"/>
+                        <field name="ward_location_id" readonly="1"/>
+                        <field name="bed_src_location_id" readonly="1" />
                     </group>
                     <group string="To" colspan="4" col="2">
                         <field name="bed_dst_location_id" width="100" domain="[('id','child_of',ward_location_id),


### PR DESCRIPTION
Removed the shift coordinators edit permissions but the 'form open' button was still appearing. Set the `no_open` option on the widget to `true` and this removed the button.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.