### PR TITLE
[EOBS-2405] Nursing Re-Allocation - Users added to 'Nursing Staff on shift' are not added to the Shift

### DIFF
--- a/shift_allocation/tests/nh_clinical_staff_reallocation/test_staff_reallocation_integration.py
+++ b/shift_allocation/tests/nh_clinical_staff_reallocation/test_staff_reallocation_integration.py
@@ -95,6 +95,32 @@ class TestStaffReallocationIntegration(TransactionCase):
         for resp_allocation in resp_allocations:
             self.assertIn(self.bed.id, resp_allocation.location_ids.ids)
 
+    def test_complete_adds_nurse_to_shift(self):
+        shift_model = self.env['nh.clinical.shift']
+        shift = shift_model.get_latest_shift_for_ward(self.ward.id)
+
+        nurse = self.test_utils_model.create_nurse()
+        self.assertNotIn(nurse, shift.nurses)
+        self.wizard.user_ids += nurse
+
+        self.wizard.reallocate()
+        self.wizard.complete()
+
+        self.assertIn(nurse, shift.nurses)
+
+    def test_complete_adds_hca_to_shift(self):
+        shift_model = self.env['nh.clinical.shift']
+        shift = shift_model.get_latest_shift_for_ward(self.ward.id)
+
+        hca = self.test_utils_model.create_hca()
+        self.assertNotIn(hca, shift.hcas)
+        self.wizard.user_ids += hca
+
+        self.wizard.reallocate()
+        self.wizard.complete()
+
+        self.assertIn(hca, shift.hcas)
+
     def test_shift_coordinator_uses_twice(self):
         """
         Test that on completing that the wizard now:

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of NHClinical. See LICENSE file for full copyright and licensing details
-from openerp.osv import osv, fields
 from openerp import api
+from openerp.osv import osv, fields
 
 
 def list_diff(a, b):
@@ -412,6 +412,16 @@ class StaffReallocationWizard(osv.TransientModel):
         return {'type': 'ir.actions.act_window_close'}
 
     def _update_shift(self, cr, uid, wizard):
+        """
+        Update the fields of the current shift record for the ward to reflect
+        any changes made in the wizard (usually via the 'Nursing staff on
+        shift' field).
+
+        :param cr:
+        :param uid:
+        :param wizard:
+        :return:
+        """
         nurses = wizard.user_ids.filter_nurses(wizard.user_ids)
         hcas = wizard.user_ids.filter_hcas(wizard.user_ids)
 

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -419,7 +419,7 @@ class StaffReallocationWizard(osv.TransientModel):
 
         :param cr:
         :param uid:
-        :param wizard:
+        :param wizard: nh.clinical.staff.reallocation record
         :return:
         """
         nurses = wizard.user_ids.filter_nurses(wizard.user_ids)


### PR DESCRIPTION
Adding or removing nurses or HCAs from the Nursing Staff on shift field of the reallocation wizard now correctly adds or removes them from the shift which ensures that the change is reflected when the wizards are opened again in future.

---

Before this pull request can be merged the following must be true.
- [ ] Unit tests pass (Travis integration).
- [ ] No code quality issues (Codacy integration).
- [ ] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [ ] All client module unit tests pass.
- [ ] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [ ] The JIRA issue contains a description of the root cause and the solution in the comments.
- [ ] There are no bugs against the JIRA issues in the current sprint.