### PR TITLE
[EOBS-2405] Nursing Re-Allocation - Users added to 'Nursing Staff on shift' are not added to the Shift

### DIFF
--- a/shift_allocation/tests/nh_clinical_staff_reallocation/test_reallocate.py
+++ b/shift_allocation/tests/nh_clinical_staff_reallocation/test_reallocate.py
@@ -96,6 +96,7 @@ class TestStaffReallocationReallocate(SingleTransactionCase):
                     allocatingwrite = args[4]
             return True
 
+        # TODO EOBS-2534 Refactor test_reallocate module in shift allocation
         def mock_update_shift(*args, **kwargs):
             pass
 

--- a/shift_allocation/tests/nh_clinical_staff_reallocation/test_reallocate.py
+++ b/shift_allocation/tests/nh_clinical_staff_reallocation/test_reallocate.py
@@ -96,6 +96,9 @@ class TestStaffReallocationReallocate(SingleTransactionCase):
                     allocatingwrite = args[4]
             return True
 
+        def mock_update_shift(*args, **kwargs):
+            pass
+
         self.allocation_pool._patch_method('_get_default_allocatings',
                                            mock_get_default_allocatings)
         self.allocation_pool._patch_method('read',
@@ -109,6 +112,7 @@ class TestStaffReallocationReallocate(SingleTransactionCase):
         self.allocation_pool._patch_method('unfollow_patients_in_locations',
                                            mock_user_patient_unfollow)
         self.allocation_pool._patch_method('write', mock_reallocation_write)
+        self.allocation_pool._patch_method('_update_shift', mock_update_shift)
 
     def tearDown(self):
         super(TestStaffReallocationReallocate, self).tearDown()
@@ -120,6 +124,7 @@ class TestStaffReallocationReallocate(SingleTransactionCase):
         self.allocation_pool._revert_method('unfollow_patients_in_locations')
         self.allocation_pool._revert_method('write')
         self.allocation_pool._revert_method('get_users_for_locations')
+        self.allocation_pool._revert_method('_update_shift')
 
     def test_calls_resp_unfollow_on_user_deallocated(self):
         """

--- a/shift_allocation/tests/nh_clinical_staff_reallocation/test_staff_reallocation_integration.py
+++ b/shift_allocation/tests/nh_clinical_staff_reallocation/test_staff_reallocation_integration.py
@@ -95,7 +95,7 @@ class TestStaffReallocationIntegration(TransactionCase):
         for resp_allocation in resp_allocations:
             self.assertIn(self.bed.id, resp_allocation.location_ids.ids)
 
-    def test_complete_adds_nurse_to_shift(self):
+    def test_reallocate_adds_nurse_to_shift(self):
         """
         A nurse added to the nursing staff on shift field should be in the
         shift after the complete method is called.
@@ -108,11 +108,10 @@ class TestStaffReallocationIntegration(TransactionCase):
         self.wizard.user_ids += nurse
 
         self.wizard.reallocate()
-        self.wizard.complete()
 
         self.assertIn(nurse, shift.nurses)
 
-    def test_complete_adds_hca_to_shift(self):
+    def test_reallocate_adds_hca_to_shift(self):
         """
         A HCA added to the nursing staff on shift field should be in the
         shift after the complete method is called.
@@ -125,11 +124,10 @@ class TestStaffReallocationIntegration(TransactionCase):
         self.wizard.user_ids += hca
 
         self.wizard.reallocate()
-        self.wizard.complete()
 
         self.assertIn(hca, shift.hcas)
 
-    def test_complete_only_sets_staff_in_wizard_on_shift(self):
+    def test_reallocate_only_sets_staff_in_wizard_on_shift(self):
         """
         Only the staff in the 'Nursing staff on shift' field in the wizard
         should be on the shift after the complete method is called.
@@ -147,7 +145,6 @@ class TestStaffReallocationIntegration(TransactionCase):
         self.wizard.user_ids += hca
 
         self.wizard.reallocate()
-        self.wizard.complete()
 
         expected_users = nurse + hca
         actual_users = shift.nurses + shift.hcas

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -342,12 +342,12 @@ class StaffReallocationWizard(osv.TransientModel):
         if not isinstance(ids, int):
             raise ValueError('reallocate expected integer')
         user_pool = self.pool['res.users']
-        wiz = self.read(
+        wizard = self.read(
             cr, uid, ids, ['location_ids', 'user_ids'], context=context)
-        location_ids = wiz.get('location_ids')
+        location_ids = wizard.get('location_ids')
         loc_user_ids = self.get_users_for_locations(
             cr, uid, location_ids, context=context)
-        user_ids = wiz.get('user_ids')
+        user_ids = wizard.get('user_ids')
         recompute = False
         for u_id in loc_user_ids:
             if u_id not in user_ids and u_id != uid:
@@ -369,6 +369,10 @@ class StaffReallocationWizard(osv.TransientModel):
             self.write(cr, uid, ids,
                        {'allocating_ids': [[6, 0, allocating_ids]]},
                        context=context)
+
+        wizard = self.browse(cr, uid, ids, context=context)
+        self._update_shift(cr, uid, wizard)
+
         return {
             'type': 'ir.actions.act_window',
             'name': 'Nursing Re-Allocation',
@@ -408,8 +412,6 @@ class StaffReallocationWizard(osv.TransientModel):
         for key, value in allocation.iteritems():
             self.responsibility_allocation_activity(cr, uid, key, value,
                                                     context=context)
-
-        self._update_shift(cr, uid, wizard)
 
         return {'type': 'ir.actions.act_window_close'}
 

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of NHClinical. See LICENSE file for full copyright and licensing details
-from openerp.osv import osv, fields
 from openerp import api
+from openerp.osv import osv, fields
 
 
 def list_diff(a, b):
@@ -412,6 +412,16 @@ class StaffReallocationWizard(osv.TransientModel):
         return {'type': 'ir.actions.act_window_close'}
 
     def _update_shift(self, cr, uid, wizard):
+        """
+        Update the fields of the current shift record for the ward to reflect
+        any changes made in the wizard (usually via the 'Nursing staff on
+        shift' field).
+
+        :param cr:
+        :param uid:
+        :param wizard:
+        :return:
+        """
         nurses = wizard.user_ids.filter_nurses(wizard.user_ids)
         hcas = wizard.user_ids.filter_hcas(wizard.user_ids)
 

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -420,7 +420,6 @@ class StaffReallocationWizard(osv.TransientModel):
         :param cr:
         :param uid:
         :param wizard: nh.clinical.staff.reallocation record
-        :return:
         """
         nurses = wizard.user_ids.filter_nurses(wizard.user_ids)
         hcas = wizard.user_ids.filter_hcas(wizard.user_ids)

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -383,13 +383,15 @@ class StaffReallocationWizard(osv.TransientModel):
             ids = ids[0]
         if not isinstance(ids, int):
             raise ValueError('Invalid ID passed to complete')
+        allocating_pool = self.pool['nh.clinical.allocating']
         wizard = self.browse(cr, uid, ids, context=context)
 
         allocation = {
             u.id: [l.id for l in u.location_ids if l.id not
                    in wizard.location_ids.ids] for u in wizard.user_ids}
-
-        for allocating in wizard.allocating_ids:
+        for allocating in allocating_pool.browse(
+                cr, uid, [a.id for a in wizard.allocating_ids],
+                context=context):
             if allocating.nurse_id:
                 allocation[allocating.nurse_id.id].append(
                     allocating.location_id.id)

--- a/shift_allocation/wizard/user_allocation.py
+++ b/shift_allocation/wizard/user_allocation.py
@@ -419,7 +419,7 @@ class StaffReallocationWizard(osv.TransientModel):
 
         :param cr:
         :param uid:
-        :param wizard:
+        :param wizard: nh.clinical.staff.reallocation record
         :return:
         """
         nurses = wizard.user_ids.filter_nurses(wizard.user_ids)

--- a/shift_allocation/wizard/user_allocation_view.xml
+++ b/shift_allocation/wizard/user_allocation_view.xml
@@ -85,7 +85,7 @@
             <field name="arch" type="xml">
                 <form string="Staff Allocation Wizard" version="7.0">
                     <header>
-                        <field name="stage" readonly="1" widget="statusbar" clickable="False" options="{'fold_field': 'fold'}"/>
+                        <field name="stage" readonly="1" widget="statusbar" options="{'fold_field': 'fold', 'clickable': false}"/>
                         <button string="Start" type="object" name="submit_ward" class="oe_highlight"
                                 attrs="{'invisible': [['stage','!=','wards']]}"/>
                         <button string="Deallocate Previous Shift" type="object" name="deallocate" class="oe_highlight"
@@ -140,7 +140,7 @@
             <field name="arch" type="xml">
                 <form string="Staff Re-Allocation Wizard" version="7.0">
                     <header>
-                        <field name="stage" readonly="1" widget="statusbar" clickable="False" options="{'fold_field': 'fold'}"/>
+                        <field name="stage" readonly="1" widget="statusbar" options="{'fold_field': 'fold', 'clickable': false}"/>
                         <button string="Re-Allocate" type="object" name="reallocate" class="oe_highlight"
                                 attrs="{'invisible': [['stage','!=','users']]}"/>
                         <button string="Confirm Allocation" type="object" name="complete" class="oe_highlight"
@@ -185,7 +185,7 @@
             <field name="arch" type="xml">
                 <form string="Doctor Allocation Wizard" version="7.0">
                     <header>
-                        <field name="stage" readonly="1" widget="statusbar" clickable="False" options="{'fold_field': 'fold'}"/>
+                        <field name="stage" readonly="1" widget="statusbar" options="{'fold_field': 'fold', 'clickable': false}"/>
                         <button string="Deallocate Previous Shift" type="object" name="deallocate" class="oe_highlight"
                                 attrs="{'invisible': [['stage','!=','review']]}"/>
                         <button string="Confirm Allocation" type="object" name="submit_users" class="oe_highlight"


### PR DESCRIPTION
Adding or removing nurses or HCAs from the Nursing Staff on shift field of the reallocation wizard now correctly adds or removes them from the shift which ensures that the change is reflected when the wizards are opened again in future.

---

Before this pull request can be merged the following must be true.
- [x] Unit tests pass (Travis integration).
- [x] No code quality issues (Codacy integration).
- [x] Approval from at least one developer and at least one tester.

If you are a BJSS contributor there are some additional conditions.
- [x] All client module unit tests pass.
- [x] The *Pull Request* field in the work tab of the JIRA issue is populated.
- [x] The JIRA issue contains a description of the root cause and the solution in the comments.
- [x] There are no bugs against the JIRA issues in the current sprint.